### PR TITLE
Source link and typo fixes

### DIFF
--- a/03-methods_interfaces_embedding/03-embedding/example2/example2.go
+++ b/03-methods_interfaces_embedding/03-embedding/example2/example2.go
@@ -44,7 +44,7 @@ func main() {
 		level: "super",
 	}
 
-	// We can acces the inner type's method direectly.
+	// We can acces the inner type's method directly.
 	ad.user.notify()
 
 	// The inner type's method is promoted.

--- a/03-methods_interfaces_embedding/03-embedding/example4/example4.go
+++ b/03-methods_interfaces_embedding/03-embedding/example4/example4.go
@@ -63,7 +63,7 @@ func main() {
 	// interface is NOT "promoted" to the outer type.
 	sendNotification(&ad)
 
-	// We can acces the inner type's method direectly.
+	// We can acces the inner type's method directly.
 	ad.user.notify()
 
 	// The inner type's method is promoted.

--- a/03-methods_interfaces_embedding/03-embedding/readme.md
+++ b/03-methods_interfaces_embedding/03-embedding/readme.md
@@ -22,7 +22,7 @@ http://www.goinggo.net/2014/05/methods-interfaces-and-embedded-types.html
 
 [Embedded types and interfaces](example3/example3.go) ([Go Playground](http://play.golang.org/p/3UVTkwprkM))
 
-[Outer and inner type interface implementations](example4/example5.go) ([Go Playground](http://play.golang.org/p/Qn32CmIAIn))
+[Outer and inner type interface implementations](example4/example4.go) ([Go Playground](http://play.golang.org/p/Qn32CmIAIn))
 
 ## Exercises
 


### PR DESCRIPTION
This PR fixes a link to some Go source code in the **Embedding - Methods, Interfaces and Embedding** section, as well as a couple typos I noticed.

Thanks for providing this great material!